### PR TITLE
Исправить публикацию на Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
     "update": "node scripts/update-rates.mjs",
     "build": "node scripts/build-site.mjs"
   },
-  "engines": {"node": ">=22"}
+  "engines": {"node": "22.x"}
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "_site"
+}


### PR DESCRIPTION
## Причина ошибки

Vercel был настроен ожидать каталог `public`, тогда как `npm run build` собирает статический сайт в `_site`. Поэтому сборка завершалась сообщением `No Output Directory named "public" found`.

Дополнительно в настройках старого Vercel-проекта оставался Node.js 12, а `package.json` содержал слишком широкий диапазон `>=22`, из-за чего Vercel показывал два предупреждения.

## Исправление

- добавлен `vercel.json` с `buildCommand: npm run build`;
- выходной каталог явно задан как `_site`;
- версия Node.js закреплена на `22.x`, поэтому устаревшая настройка Node 12 больше не используется и не произойдёт неожиданного перехода на будущую major-версию.

## Проверка

Preview deployment Vercel для последнего коммита завершился успешно.