### PR TITLE
Сделать график нагляднее и починить значения при наведении

### DIFF
--- a/.github/workflows/validate-site.yml
+++ b/.github/workflows/validate-site.yml
@@ -1,0 +1,25 @@
+name: Validate site
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Check and build
+        run: |
+          npm run check
+          npm run build

--- a/app-chart.js
+++ b/app-chart.js
@@ -2,8 +2,8 @@ function renderChart() {
   const view = currentView();
   const compact = matchMedia("(max-width: 720px)").matches;
   const width = Math.max(320, Math.round(el.wrap.clientWidth || 1000));
-  const height = compact ? 430 : 520;
-  const margin = { top: 54, right: compact ? 16 : 28, bottom: 58, left: compact ? 48 : 60 };
+  const height = compact ? 450 : 540;
+  const margin = { top: 56, right: compact ? 84 : 108, bottom: 66, left: compact ? 48 : 60 };
   const plotW = width - margin.left - margin.right;
   const plotH = height - margin.top - margin.bottom;
 
@@ -22,7 +22,7 @@ function renderChart() {
 
   if (!values.length) {
     el.chart.innerHTML = '<title id="svg-title">График USD/RUB</title><desc id="svg-desc">Нет данных за выбранный период.</desc>';
-    el.tooltip.hidden = true;
+    setTooltipVisible(false);
     renderInspector(null);
     return;
   }
@@ -32,7 +32,7 @@ function renderChart() {
   const y = (value) => margin.top + (scale.max - value) / (scale.max - scale.min) * plotH;
   const out = [
     '<title id="svg-title">Внутридневной график USD/RUB</title>',
-    '<desc id="svg-desc">Курсы покупки и продажи Freedom Bank, часовые свечи USDRUBF и лучшие часы по разрыву с рынком.</desc>'
+    '<desc id="svg-desc">Курсы покупки и продажи Freedom Bank, часовые свечи USDRUBF и лучшие часы по разрыву с рынком. Наведите курсор на любую часть графика, чтобы увидеть точные значения.</desc>'
   ];
 
   for (const tick of scale.ticks) {
@@ -45,7 +45,7 @@ function renderChart() {
     const xp = x(tick);
     const parts = timeTickParts(tick, view.end - view.start);
     out.push(`<line class="grid-line vertical" x1="${xp}" y1="${margin.top}" x2="${xp}" y2="${height - margin.bottom}"/>`);
-    out.push(`<text class="axis-label axis-x" x="${xp}" y="${height - 28}"><tspan x="${xp}">${escapeHtml(parts[0])}</tspan>${parts[1] ? `<tspan x="${xp}" dy="13">${escapeHtml(parts[1])}</tspan>` : ""}</text>`);
+    out.push(`<text class="axis-label axis-x" x="${xp}" y="${height - 30}"><tspan x="${xp}">${escapeHtml(parts[0])}</tspan>${parts[1] ? `<tspan x="${xp}" dy="13">${escapeHtml(parts[1])}</tspan>` : ""}</text>`);
   }
 
   if (!state.hidden.has("buy") && !state.hidden.has("sell") && view.freedom.length) {
@@ -55,17 +55,22 @@ function renderChart() {
   drawBank("buy", out, view.freedom, x, y);
   drawBank("sell", out, view.freedom, x, y);
   drawMarket(out, view.market, x, y);
+  drawEndLabels(out, view, x, y, margin, width, height);
 
   const opportunities = computeOpportunities(view.comparisons);
   drawOpportunities(out, opportunities, x, y, view, margin, height, width);
 
-  out.push(`<g id="hover" hidden>
+  out.push(`<g id="hover" class="hover-layer is-hidden" aria-hidden="true">
     <line class="hover-line" id="hover-line" y1="${margin.top}" y2="${height - margin.bottom}"/>
-    <circle class="hover-point buy" id="hover-buy" r="5" hidden/>
-    <circle class="hover-point sell" id="hover-sell" r="5" hidden/>
-    <circle class="hover-point market" id="hover-market" r="5" hidden/>
+    ${hoverSeriesMarkup("buy")}
+    ${hoverSeriesMarkup("sell")}
+    ${hoverSeriesMarkup("market")}
+    <g class="hover-time" id="hover-time">
+      <rect width="148" height="24" rx="7"/>
+      <text id="hover-time-text" x="74" y="16"></text>
+    </g>
   </g>`);
-  out.push(`<rect class="capture" tabindex="0" role="slider" aria-label="Выбор времени на графике" x="${margin.left}" y="${margin.top}" width="${plotW}" height="${plotH}"/>`);
+  out.push(`<rect class="capture" tabindex="0" role="slider" aria-label="Выбор времени на графике" aria-valuemin="${Math.round(view.start)}" aria-valuemax="${Math.round(view.end)}" x="${margin.left}" y="${margin.top}" width="${plotW}" height="${plotH}" pointer-events="all"/>`);
 
   el.chart.innerHTML = out.join("");
   const events = uniqueSorted([
@@ -81,6 +86,17 @@ function renderChart() {
     state.selectedMs = view.comparisons.at(-1)?.ms || events.at(-1) || null;
   }
   if (Number.isFinite(state.selectedMs)) showSnapshot(state.selectedMs, false, true);
+}
+
+function hoverSeriesMarkup(key) {
+  return `<g class="hover-series ${key} is-hidden" id="hover-series-${key}" aria-hidden="true">
+    <line class="hover-guide ${key}" id="hover-guide-${key}"/>
+    <circle class="hover-point ${key}" id="hover-${key}" r="6"/>
+    <g class="hover-badge ${key}" id="hover-badge-${key}">
+      <rect width="76" height="24" rx="7"/>
+      <text x="38" y="16"></text>
+    </g>
+  </g>`;
 }
 
 function drawBank(key, out, points, x, y) {
@@ -117,10 +133,10 @@ function drawBank(key, out, points, x, y) {
     }
   }
 
-  const every = Math.max(1, Math.ceil(actual.length / 110));
+  const every = Math.max(1, Math.ceil(actual.length / 90));
   actual.forEach((point, index) => {
     if (index % every !== 0 && index !== actual.length - 1) return;
-    out.push(`<circle class="series-point ${key} ${lineQualityClass(point)}" cx="${x(point.ms)}" cy="${y(point[key])}" r="${point.resolution === "intraday" ? 3.2 : 2.5}"><title>${formatDateTime(point.ms)} — ${rate.format(point[key])}</title></circle>`);
+    out.push(`<circle class="series-point ${key} ${lineQualityClass(point)}" cx="${x(point.ms)}" cy="${y(point[key])}" r="${point.resolution === "intraday" ? 3.6 : 2.8}"><title>${formatDateTime(point.ms)} — ${rate.format(point[key])}</title></circle>`);
   });
 }
 
@@ -174,11 +190,61 @@ function drawMarket(out, points, x, y) {
     out.push(`<path class="series-line market market-gap" d="M${x(from.ms).toFixed(2)},${y(from.close).toFixed(2)}L${x(to.ms).toFixed(2)},${y(to.close).toFixed(2)}"><title>Перерыв в торгах</title></path>`);
   }
 
-  const every = Math.max(1, Math.ceil(points.length / 110));
+  const every = Math.max(1, Math.ceil(points.length / 90));
   points.forEach((point, index) => {
     if (index % every !== 0 && index !== points.length - 1) return;
-    out.push(`<circle class="series-point market" cx="${x(point.ms)}" cy="${y(point.close)}" r="2.5"><title>${formatDateTime(point.ms)} — ${rate.format(point.close)}</title></circle>`);
+    out.push(`<circle class="series-point market" cx="${x(point.ms)}" cy="${y(point.close)}" r="3"><title>${formatDateTime(point.ms)} — ${rate.format(point.close)}</title></circle>`);
   });
+}
+
+function drawEndLabels(out, view, x, y, margin, width, height) {
+  const entries = [];
+  const bank = view.freedom.at(-1);
+  const market = view.market.at(-1);
+
+  if (bank && !state.hidden.has("buy") && Number.isFinite(bank.buy)) {
+    entries.push({ key: "buy", value: bank.buy, ms: bank.plotMs ?? bank.ms, sourceY: y(bank.buy), title: "Freedom покупает" });
+  }
+  if (bank && !state.hidden.has("sell") && Number.isFinite(bank.sell)) {
+    entries.push({ key: "sell", value: bank.sell, ms: bank.plotMs ?? bank.ms, sourceY: y(bank.sell), title: "Freedom продаёт" });
+  }
+  if (market && !state.hidden.has("market") && Number.isFinite(market.close)) {
+    entries.push({ key: "market", value: market.close, ms: market.ms, sourceY: y(market.close), title: "USDRUBF" });
+  }
+  if (!entries.length) return;
+
+  const labelYs = layoutChartLabels(entries.map((entry) => ({ ...entry, targetY: entry.sourceY })), margin.top + 13, height - margin.bottom - 13, 25);
+  const tagX = width - margin.right + 10;
+  const tagWidth = Math.max(60, margin.right - 18);
+
+  for (const entry of labelYs) {
+    const sourceX = x(entry.ms);
+    out.push(`<g class="end-label ${entry.key}">
+      <line x1="${sourceX}" y1="${entry.sourceY}" x2="${tagX - 4}" y2="${entry.targetY}"/>
+      <rect x="${tagX}" y="${entry.targetY - 11}" width="${tagWidth}" height="22" rx="7"/>
+      <text x="${tagX + tagWidth / 2}" y="${entry.targetY + 4}">${escapeHtml(rate.format(entry.value))}</text>
+      <title>${escapeHtml(entry.title)}: ${escapeHtml(rate.format(entry.value))} · ${escapeHtml(formatDateTime(entry.ms))}</title>
+    </g>`);
+  }
+}
+
+function layoutChartLabels(entries, minY, maxY, gap) {
+  const sorted = [...entries].sort((a, b) => a.targetY - b.targetY);
+  for (let index = 1; index < sorted.length; index += 1) {
+    sorted[index].targetY = Math.max(sorted[index].targetY, sorted[index - 1].targetY + gap);
+  }
+  if (sorted.length && sorted.at(-1).targetY > maxY) {
+    const shift = sorted.at(-1).targetY - maxY;
+    sorted.forEach((entry) => { entry.targetY -= shift; });
+  }
+  for (let index = sorted.length - 2; index >= 0; index -= 1) {
+    sorted[index].targetY = Math.min(sorted[index].targetY, sorted[index + 1].targetY - gap);
+  }
+  if (sorted.length && sorted[0].targetY < minY) {
+    const shift = minY - sorted[0].targetY;
+    sorted.forEach((entry) => { entry.targetY += shift; });
+  }
+  return sorted;
 }
 
 function drawOpportunities(out, opportunities, x, y, view, margin, height, width) {

--- a/app-interaction.js
+++ b/app-interaction.js
@@ -3,27 +3,38 @@ function bindChartInteraction() {
   const capture = el.chart.querySelector(".capture");
   if (!capture || !context.events.length) return;
 
+  ensureChartHint();
+  setTooltipVisible(false);
+
   const move = (event) => {
-    if (state.pinned && event.pointerType !== "mouse") return;
+    if (!Number.isFinite(event.clientX)) return;
     const rect = el.chart.getBoundingClientRect();
+    if (!rect.width) return;
     const svgX = (event.clientX - rect.left) / rect.width * context.width;
     const ratio = Math.max(0, Math.min(1, (svgX - context.margin.left) / context.plotW));
     const target = context.view.start + ratio * (context.view.end - context.view.start);
     const nearest = nearestValue(context.events, target);
     showSnapshot(nearest, true, false);
+    markChartInteracted();
   };
 
+  capture.addEventListener("pointerenter", move);
   capture.addEventListener("pointermove", move);
   capture.addEventListener("pointerdown", (event) => {
     move(event);
     state.pinned = true;
     capture.classList.add("pinned");
+    if (Number.isFinite(event.pointerId)) capture.setPointerCapture?.(event.pointerId);
   });
   capture.addEventListener("pointerleave", () => {
-    if (!state.pinned) el.tooltip.hidden = true;
+    if (!state.pinned) setTooltipVisible(false);
   });
   capture.addEventListener("pointercancel", () => {
-    if (!state.pinned) el.tooltip.hidden = true;
+    if (!state.pinned) setTooltipVisible(false);
+  });
+  capture.addEventListener("focus", () => {
+    const selected = Number.isFinite(state.selectedMs) ? state.selectedMs : context.events.at(-1);
+    if (Number.isFinite(selected)) showSnapshot(selected, true, false);
   });
   capture.addEventListener("keydown", (event) => {
     if (!["ArrowLeft", "ArrowRight", "Home", "End", "Escape"].includes(event.key)) return;
@@ -31,7 +42,7 @@ function bindChartInteraction() {
     if (event.key === "Escape") {
       state.pinned = false;
       capture.classList.remove("pinned");
-      el.tooltip.hidden = true;
+      setTooltipVisible(false);
       return;
     }
     let index = Math.max(0, context.events.findIndex((value) => value >= (state.selectedMs ?? context.events.at(-1))));
@@ -40,8 +51,25 @@ function bindChartInteraction() {
     if (event.key === "Home") index = 0;
     if (event.key === "End") index = context.events.length - 1;
     state.pinned = true;
+    capture.classList.add("pinned");
     showSnapshot(context.events[index], true, false);
+    markChartInteracted();
   });
+}
+
+function ensureChartHint() {
+  let hint = el.wrap.querySelector("#chart-interaction-hint");
+  if (hint) return hint;
+  hint = document.createElement("div");
+  hint.id = "chart-interaction-hint";
+  hint.className = "chart-interaction-hint";
+  hint.innerHTML = '<span aria-hidden="true">↔</span><span>Наведите на график — появятся точное время и значения. Нажмите, чтобы закрепить точку.</span><span class="hint-keys"><kbd>←</kbd><kbd>→</kbd></span>';
+  el.wrap.append(hint);
+  return hint;
+}
+
+function markChartInteracted() {
+  el.wrap.querySelector("#chart-interaction-hint")?.classList.add("is-muted");
 }
 
 function selectTimestamp(ms, pin = true) {
@@ -60,6 +88,7 @@ function selectTimestamp(ms, pin = true) {
     return;
   }
   showSnapshot(ms, true, false);
+  markChartInteracted();
   el.wrap.scrollIntoView({ behavior: "smooth", block: "center" });
 }
 
@@ -73,36 +102,155 @@ function showSnapshot(ms, showTooltip, persistent) {
 
   const layer = el.chart.querySelector("#hover");
   const line = el.chart.querySelector("#hover-line");
-  const points = {
-    buy: el.chart.querySelector("#hover-buy"),
-    sell: el.chart.querySelector("#hover-sell"),
-    market: el.chart.querySelector("#hover-market")
-  };
   if (!layer || !line) return;
 
   const xp = context.x(snapshot.ms);
-  layer.hidden = false;
+  setSvgVisible(layer, true);
   line.setAttribute("x1", xp);
   line.setAttribute("x2", xp);
 
-  for (const [key, point] of Object.entries(points)) {
-    const value = snapshot[key];
-    point.hidden = !Number.isFinite(value) || state.hidden.has(key);
-    if (!point.hidden) {
-      point.setAttribute("cx", xp);
-      point.setAttribute("cy", context.y(value));
-    }
+  const series = [
+    { key: "buy", value: snapshot.buy },
+    { key: "sell", value: snapshot.sell },
+    { key: "market", value: snapshot.market }
+  ];
+  const visibleSeries = [];
+
+  for (const entry of series) {
+    const group = el.chart.querySelector(`#hover-series-${entry.key}`);
+    const point = el.chart.querySelector(`#hover-${entry.key}`);
+    const badge = el.chart.querySelector(`#hover-badge-${entry.key}`);
+    const badgeText = badge?.querySelector("text");
+    const guide = el.chart.querySelector(`#hover-guide-${entry.key}`);
+    const visible = Boolean(group && point && badge && badgeText && guide)
+      && Number.isFinite(entry.value)
+      && !state.hidden.has(entry.key);
+
+    setSvgVisible(group, visible);
+    if (!visible) continue;
+
+    const cy = context.y(entry.value);
+    point.setAttribute("cx", xp);
+    point.setAttribute("cy", cy);
+    badgeText.textContent = rate.format(entry.value);
+    visibleSeries.push({ ...entry, group, point, badge, guide, cy });
   }
 
-  if (!showTooltip && !state.pinned && !persistent) return;
-  el.tooltip.innerHTML = tooltipHtml(snapshot);
-  el.tooltip.hidden = false;
+  placeHoverBadges(visibleSeries, xp, context);
+  updateHoverTime(snapshot.ms, xp, context);
+  updateCaptureAccessibility(snapshot);
+
+  const shouldShowTooltip = showTooltip || state.pinned;
+  if (shouldShowTooltip) {
+    el.tooltip.innerHTML = tooltipHtml(snapshot);
+    setTooltipVisible(true);
+    positionTooltip(snapshot, xp, context);
+  } else if (persistent) {
+    setTooltipVisible(false);
+  }
+}
+
+function placeHoverBadges(entries, xp, context) {
+  if (!entries.length) return;
+  const badgeWidth = 76;
+  const badgeHeight = 24;
+  const preferRight = xp < context.margin.left + context.plotW * 0.67;
+  const badgeX = preferRight
+    ? clampNumber(xp + 13, context.margin.left + 4, context.width - context.margin.right - badgeWidth - 4)
+    : clampNumber(xp - badgeWidth - 13, context.margin.left + 4, context.width - context.margin.right - badgeWidth - 4);
+  const laidOut = layoutHoverLabels(entries, context.margin.top + badgeHeight / 2 + 3, context.height - context.margin.bottom - badgeHeight / 2 - 3, badgeHeight + 4);
+
+  for (const entry of laidOut) {
+    const tagY = entry.labelY - badgeHeight / 2;
+    entry.badge.setAttribute("transform", `translate(${badgeX},${tagY})`);
+    entry.guide.setAttribute("x1", xp);
+    entry.guide.setAttribute("y1", entry.cy);
+    entry.guide.setAttribute("x2", preferRight ? badgeX : badgeX + badgeWidth);
+    entry.guide.setAttribute("y2", entry.labelY);
+  }
+}
+
+function layoutHoverLabels(entries, minY, maxY, gap) {
+  const sorted = entries.map((entry) => ({ ...entry, labelY: entry.cy })).sort((a, b) => a.labelY - b.labelY);
+  for (let index = 1; index < sorted.length; index += 1) {
+    sorted[index].labelY = Math.max(sorted[index].labelY, sorted[index - 1].labelY + gap);
+  }
+  if (sorted.at(-1)?.labelY > maxY) {
+    const shift = sorted.at(-1).labelY - maxY;
+    sorted.forEach((entry) => { entry.labelY -= shift; });
+  }
+  for (let index = sorted.length - 2; index >= 0; index -= 1) {
+    sorted[index].labelY = Math.min(sorted[index].labelY, sorted[index + 1].labelY - gap);
+  }
+  if (sorted[0]?.labelY < minY) {
+    const shift = minY - sorted[0].labelY;
+    sorted.forEach((entry) => { entry.labelY += shift; });
+  }
+  return sorted;
+}
+
+function updateHoverTime(ms, xp, context) {
+  const group = el.chart.querySelector("#hover-time");
+  const text = el.chart.querySelector("#hover-time-text");
+  if (!group || !text) return;
+  const width = 148;
+  const x = clampNumber(xp - width / 2, context.margin.left, context.width - context.margin.right - width);
+  const y = context.height - context.margin.bottom + 12;
+  group.setAttribute("transform", `translate(${x},${y})`);
+  text.textContent = shortDateTime.format(new Date(ms));
+}
+
+function updateCaptureAccessibility(snapshot) {
+  const capture = el.chart.querySelector(".capture");
+  if (!capture) return;
+  capture.setAttribute("aria-valuenow", String(Math.round(snapshot.ms)));
+  capture.setAttribute("aria-valuetext", [
+    formatDateTime(snapshot.ms),
+    Number.isFinite(snapshot.buy) ? `Freedom покупает ${rate.format(snapshot.buy)}` : null,
+    Number.isFinite(snapshot.sell) ? `Freedom продаёт ${rate.format(snapshot.sell)}` : null,
+    Number.isFinite(snapshot.market) ? `USDRUBF ${rate.format(snapshot.market)}` : null
+  ].filter(Boolean).join("; "));
+}
+
+function setSvgVisible(node, visible) {
+  if (!node) return;
+  node.classList.toggle("is-hidden", !visible);
+  node.setAttribute("aria-hidden", String(!visible));
+}
+
+function setTooltipVisible(visible) {
+  if (!el.tooltip) return;
+  el.tooltip.removeAttribute("hidden");
+  el.tooltip.classList.toggle("is-visible", visible);
+  el.tooltip.setAttribute("aria-hidden", String(!visible));
+}
+
+function positionTooltip(snapshot, xp, context) {
   const rect = el.chart.getBoundingClientRect();
+  if (!rect.width || !rect.height) return;
   const screenX = xp / context.width * rect.width;
-  const visibleY = [snapshot.buy, snapshot.sell, snapshot.market].filter(Number.isFinite).map(context.y);
-  const top = visibleY.length ? Math.min(...visibleY) / context.height * rect.height : rect.height / 2;
-  el.tooltip.style.left = `${Math.max(115, Math.min(rect.width - 115, screenX))}px`;
-  el.tooltip.style.top = `${Math.max(105, top)}px`;
+  const visibleY = [snapshot.buy, snapshot.sell, snapshot.market]
+    .filter(Number.isFinite)
+    .map((value) => context.y(value) / context.height * rect.height);
+  const anchorY = visibleY.length ? Math.min(...visibleY) : rect.height / 2;
+  const boxWidth = el.tooltip.offsetWidth || Math.min(286, rect.width - 24);
+  const boxHeight = el.tooltip.offsetHeight || 190;
+  const padding = 12;
+
+  let left = screenX + 18;
+  if (left + boxWidth > rect.width - padding) left = screenX - boxWidth - 18;
+  left = clampNumber(left, padding, Math.max(padding, rect.width - boxWidth - padding));
+
+  let top = anchorY - boxHeight - 16;
+  if (top < padding) top = anchorY + 18;
+  top = clampNumber(top, padding, Math.max(padding, rect.height - boxHeight - padding));
+
+  el.tooltip.style.left = `${left}px`;
+  el.tooltip.style.top = `${top}px`;
+}
+
+function clampNumber(value, min, max) {
+  return Math.max(min, Math.min(max, value));
 }
 
 function snapshotAt(ms, view) {
@@ -120,7 +268,8 @@ function snapshotAt(ms, view) {
   }
 
   const bank = findAtOrBefore(state.data.freedom, ms);
-  const marketPoint = nearestPoint(state.data.market, ms, MARKET_MAX_AGE);
+  const marketCandidate = findAtOrBefore(state.data.market, ms);
+  const marketPoint = marketCandidate && ms - marketCandidate.ms <= MARKET_MAX_AGE ? marketCandidate : null;
   if (!bank && !marketPoint) return null;
   return {
     ms,
@@ -135,16 +284,16 @@ function snapshotAt(ms, view) {
 
 function tooltipHtml(snapshot) {
   const rows = [
-    ["Freedom покупает", snapshot.buy],
-    ["Freedom продаёт", snapshot.sell],
-    ["USDRUBF", snapshot.market]
-  ].filter(([, value]) => Number.isFinite(value))
-    .map(([label, value]) => `<div class="tooltip-row"><span>${label}</span><strong>${rate.format(value)}</strong></div>`)
+    ["buy", "Freedom покупает", snapshot.buy],
+    ["sell", "Freedom продаёт", snapshot.sell],
+    ["market", "USDRUBF", snapshot.market]
+  ].filter(([, , value]) => Number.isFinite(value))
+    .map(([key, label, value]) => `<div class="tooltip-row ${key}"><span><i></i>${label}</span><strong>${rate.format(value)} ₽</strong></div>`)
     .join("");
   const gaps = Number.isFinite(snapshot.buy) && Number.isFinite(snapshot.sell) && Number.isFinite(snapshot.market)
-    ? `<div class="tooltip-gaps"><span>Купить USD: <b>${signed.format(snapshot.sell - snapshot.market)} ₽</b></span><span>Продать USD: <b>${signed.format(snapshot.market - snapshot.buy)} ₽</b></span></div>`
+    ? `<div class="tooltip-gaps"><span>Купить USD: <b>${signed.format(snapshot.sell - snapshot.market)} ₽</b></span><span>Продать USD: <b>${signed.format(snapshot.market - snapshot.buy)} ₽</b></span><span>Спред банка: <b>${rate.format(snapshot.sell - snapshot.buy)} ₽</b></span></div>`
     : "";
-  return `<div class="tooltip-date">${escapeHtml(formatDateTime(snapshot.ms))}</div>${rows}${gaps}<div class="tooltip-quality">${escapeHtml(snapshotQuality(snapshot))}</div>`;
+  return `<div class="tooltip-date"><span>${escapeHtml(formatDateTime(snapshot.ms))}</span><small>${state.pinned ? "точка закреплена" : "точные значения"}</small></div>${rows}${gaps}<div class="tooltip-quality">${escapeHtml(snapshotQuality(snapshot))}</div>`;
 }
 
 function renderInspector(snapshot) {

--- a/chart.css
+++ b/chart.css
@@ -1,37 +1,91 @@
 .chart-wrap {
   position: relative;
   width: 100%;
-  min-height: 520px;
+  min-height: 540px;
   margin-top: 20px;
+  border: 1px solid rgba(184, 210, 232, 0.06);
   border-radius: 15px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.026), rgba(255, 255, 255, 0.005));
   overflow: visible;
 }
-#chart { display: block; width: 100%; height: 520px; touch-action: pan-y; overflow: visible; }
-.grid-line { stroke: var(--grid); stroke-width: 1; vector-effect: non-scaling-stroke; }
-.grid-line.vertical { stroke-dasharray: 2 6; opacity: 0.65; }
+#chart { display: block; width: 100%; height: 540px; touch-action: pan-y; overflow: visible; }
+.grid-line { stroke: rgba(177, 202, 224, 0.13); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.grid-line.vertical { stroke-dasharray: 2 6; opacity: 0.7; }
 .axis-label { fill: var(--muted); font-size: 11px; font-variant-numeric: tabular-nums; }
 .axis-x { text-anchor: middle; }
-.area { fill: rgba(255, 184, 107, 0.055); }
-.series-line { fill: none; stroke-width: 2.35; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
+.area { fill: rgba(255, 184, 107, 0.075); }
+.series-line { fill: none; stroke-width: 2.75; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
 .series-line.buy { stroke: var(--buy); }
 .series-line.sell { stroke: var(--sell); }
-.series-line.market { stroke: var(--market); stroke-width: 2.75; }
-.series-line.derived { stroke-dasharray: 5 5; opacity: 0.76; }
+.series-line.market { stroke: var(--market); stroke-width: 3.1; }
+.series-line.derived { stroke-dasharray: 5 5; opacity: 0.78; }
 .series-line.market-gap { stroke-dasharray: 3 7; opacity: 0.38; }
-.series-point { fill: var(--surface-strong); stroke-width: 1.5; vector-effect: non-scaling-stroke; }
+.series-point { fill: var(--surface-strong); stroke-width: 1.8; vector-effect: non-scaling-stroke; }
 .series-point.buy { stroke: var(--buy); }
 .series-point.sell { stroke: var(--sell); }
 .series-point.market { fill: var(--market); stroke: var(--surface-strong); }
-.series-point.derived { stroke-dasharray: 2 2; opacity: 0.82; }
-.hover-line { stroke: rgba(220, 234, 246, 0.43); stroke-width: 1; stroke-dasharray: 3 4; vector-effect: non-scaling-stroke; }
-.hover-point { fill: var(--surface-strong); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
+.series-point.derived { stroke-dasharray: 2 2; opacity: 0.84; }
+
+.end-label { pointer-events: none; }
+.end-label line { stroke-width: 1; stroke-dasharray: 2 4; opacity: 0.55; vector-effect: non-scaling-stroke; }
+.end-label rect { fill: rgba(5, 15, 26, 0.93); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.end-label text { text-anchor: middle; font-size: 10px; font-weight: 760; font-variant-numeric: tabular-nums; }
+.end-label.buy line, .end-label.buy rect { stroke: var(--buy); }
+.end-label.sell line, .end-label.sell rect { stroke: var(--sell); }
+.end-label.market line, .end-label.market rect { stroke: var(--market); }
+.end-label.buy text { fill: var(--buy); }
+.end-label.sell text { fill: var(--sell); }
+.end-label.market text { fill: var(--market); }
+
+.hover-layer, .hover-series { pointer-events: none; transition: opacity 0.12s ease, visibility 0.12s ease; }
+.hover-layer.is-hidden, .hover-series.is-hidden { opacity: 0; visibility: hidden; }
+.hover-line { stroke: rgba(236, 244, 250, 0.68); stroke-width: 1.2; stroke-dasharray: 4 4; vector-effect: non-scaling-stroke; }
+.hover-guide { stroke-width: 1.2; stroke-dasharray: 2 3; opacity: 0.72; vector-effect: non-scaling-stroke; }
+.hover-guide.buy { stroke: var(--buy); }
+.hover-guide.sell { stroke: var(--sell); }
+.hover-guide.market { stroke: var(--market); }
+.hover-point { fill: var(--surface-strong); stroke-width: 3; vector-effect: non-scaling-stroke; filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.28)); }
 .hover-point.buy { stroke: var(--buy); }
 .hover-point.sell { stroke: var(--sell); }
 .hover-point.market { stroke: var(--market); }
-.capture { fill: transparent; cursor: crosshair; outline: none; }
-.capture:focus-visible { stroke: rgba(118, 169, 255, 0.45); stroke-width: 2; }
+.hover-badge rect { fill: rgba(4, 13, 23, 0.97); stroke-width: 1.25; vector-effect: non-scaling-stroke; }
+.hover-badge text { text-anchor: middle; font-size: 11px; font-weight: 800; font-variant-numeric: tabular-nums; }
+.hover-badge.buy rect { stroke: var(--buy); }
+.hover-badge.sell rect { stroke: var(--sell); }
+.hover-badge.market rect { stroke: var(--market); }
+.hover-badge.buy text { fill: var(--buy); }
+.hover-badge.sell text { fill: var(--sell); }
+.hover-badge.market text { fill: var(--market); }
+.hover-time rect { fill: rgba(5, 15, 26, 0.98); stroke: rgba(220, 234, 246, 0.28); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.hover-time text { fill: var(--soft); text-anchor: middle; font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.capture { fill: rgba(0, 0, 0, 0.001); pointer-events: all; cursor: crosshair; outline: none; }
+.capture:focus-visible { stroke: rgba(118, 169, 255, 0.65); stroke-width: 2; }
 .capture.pinned { cursor: ew-resize; }
+
+.chart-interaction-hint {
+  position: absolute;
+  z-index: 6;
+  top: 10px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(520px, calc(100% - 24px));
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: rgba(5, 15, 26, 0.82);
+  color: var(--soft);
+  font-size: 0.68rem;
+  line-height: 1.35;
+  pointer-events: none;
+  backdrop-filter: blur(10px);
+  transition: opacity 0.18s ease;
+}
+.chart-interaction-hint > span:first-child { color: var(--market); font-size: 1rem; }
+.chart-interaction-hint.is-muted { opacity: 0.42; }
+.hint-keys { display: inline-flex; gap: 3px; margin-left: 2px; }
+.hint-keys kbd { min-width: 20px; padding: 1px 4px; border: 1px solid var(--line-strong); border-radius: 4px; background: rgba(255, 255, 255, 0.045); text-align: center; font-size: 0.61rem; }
 
 .opportunity-line { stroke-width: 1; stroke-dasharray: 4 5; vector-effect: non-scaling-stroke; opacity: 0.62; }
 .opportunity-line.buy-op { stroke: var(--best-buy); }
@@ -52,25 +106,37 @@
 
 .tooltip {
   position: absolute;
-  z-index: 10;
-  min-width: 230px;
-  padding: 12px 13px;
+  z-index: 12;
+  width: min(286px, calc(100% - 24px));
+  padding: 13px 14px;
   border: 1px solid var(--line-strong);
-  border-radius: 12px;
-  background: rgba(5, 15, 26, 0.97);
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.4);
+  border-radius: 13px;
+  background: rgba(5, 15, 26, 0.98);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.46);
+  opacity: 0;
+  visibility: hidden;
   pointer-events: none;
-  transform: translate(-50%, calc(-100% - 14px));
+  transform: translateY(4px);
+  transition: opacity 0.12s ease, visibility 0.12s ease, transform 0.12s ease;
+  backdrop-filter: blur(14px);
 }
-.tooltip-date { margin-bottom: 9px; color: var(--soft); font-size: 0.74rem; font-weight: 700; }
-.tooltip-row { display: flex; justify-content: space-between; gap: 20px; margin-top: 6px; font-size: 0.75rem; }
-.tooltip-row strong { font-variant-numeric: tabular-nums; }
-.tooltip-gaps { display: grid; gap: 4px; margin-top: 9px; padding-top: 8px; border-top: 1px solid var(--line); color: var(--soft); font-size: 0.69rem; }
+.tooltip.is-visible { opacity: 1; visibility: visible; transform: none; }
+.tooltip-date { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 10px; color: var(--soft); font-size: 0.76rem; font-weight: 750; }
+.tooltip-date small { color: var(--muted); font-size: 0.59rem; font-weight: 600; white-space: nowrap; }
+.tooltip-row { display: flex; justify-content: space-between; gap: 20px; margin-top: 7px; font-size: 0.76rem; }
+.tooltip-row span { display: inline-flex; align-items: center; gap: 7px; color: var(--soft); }
+.tooltip-row i { width: 7px; height: 7px; border-radius: 50%; }
+.tooltip-row.buy i { background: var(--buy); box-shadow: 0 0 7px rgba(66, 221, 183, 0.45); }
+.tooltip-row.sell i { background: var(--sell); box-shadow: 0 0 7px rgba(255, 184, 107, 0.45); }
+.tooltip-row.market i { background: var(--market); box-shadow: 0 0 7px rgba(118, 169, 255, 0.45); }
+.tooltip-row strong { font-size: 0.82rem; font-variant-numeric: tabular-nums; }
+.tooltip-gaps { display: grid; gap: 5px; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); color: var(--soft); font-size: 0.69rem; }
+.tooltip-gaps span { display: flex; justify-content: space-between; gap: 12px; }
 .tooltip-gaps b { font-variant-numeric: tabular-nums; }
-.tooltip-quality { margin-top: 9px; padding-top: 8px; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.64rem; line-height: 1.4; }
+.tooltip-quality { margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.64rem; line-height: 1.45; }
 .empty { position: absolute; inset: 0; display: grid; place-items: center; color: var(--muted); font-size: 0.85rem; }
 
-.chart-key { display: flex; flex-wrap: wrap; gap: 18px; margin-top: 4px; color: var(--muted); font-size: 0.69rem; }
+.chart-key { display: flex; flex-wrap: wrap; gap: 18px; margin-top: 8px; color: var(--muted); font-size: 0.69rem; }
 .chart-key span { display: inline-flex; align-items: center; gap: 7px; }
 .sample { width: 22px; border-top: 2px solid var(--soft); }
 .sample.dashed { border-top-style: dashed; opacity: 0.7; }
@@ -166,8 +232,10 @@ footer a { color: var(--soft); text-underline-offset: 3px; }
   .card-head, .chart-head, .inspector-head, .opportunity-title { flex-direction: column; }
   .legend { width: 100%; justify-content: stretch; }
   .legend button { flex: 1; justify-content: center; min-width: 150px; }
-  .chart-wrap, #chart { height: 430px; min-height: 430px; }
-  .tooltip { min-width: 210px; }
+  .chart-wrap, #chart { height: 450px; min-height: 450px; }
+  .chart-interaction-hint { left: 10px; right: 10px; max-width: none; }
+  .hint-keys { display: none; }
+  .tooltip { width: min(268px, calc(100% - 20px)); }
   .chart-key { flex-direction: column; gap: 9px; }
   .inspector-head p:last-child { text-align: left; }
   .inspector-grid { grid-template-columns: repeat(2, 1fr); }
@@ -181,6 +249,7 @@ footer a { color: var(--soft); text-underline-offset: 3px; }
   .metric { min-height: 112px; }
   .range-button { flex-basis: calc(50% - 4px); }
   .inspector-grid { grid-template-columns: 1fr; }
+  .chart-interaction-hint { font-size: 0.63rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "usd-rub-freedom-vs-market",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "description": "Intraday Freedom Bank USD/RUB versus MOEX USDRUBF dashboard",
   "scripts": {
-    "test": "node scripts/update-rates.mjs --self-test",
+    "test": "node scripts/update-rates.mjs --self-test && node scripts/chart-ux-self-test.mjs",
     "check": "node --check app-base.js && node --check app-ui.js && node --check app-chart.js && node --check app-interaction.js && node --check app-helpers.js && node --check app.js && node --check scripts/update-rates.mjs && npm test",
     "update": "node scripts/update-rates.mjs",
     "build": "node scripts/build-site.mjs"

--- a/scripts/chart-ux-self-test.mjs
+++ b/scripts/chart-ux-self-test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+const interaction = await readFile(new URL("../app-interaction.js", import.meta.url), "utf8");
+const chart = await readFile(new URL("../app-chart.js", import.meta.url), "utf8");
+const css = await readFile(new URL("../chart.css", import.meta.url), "utf8");
+
+class FakeClassList {
+  constructor() { this.values = new Set(); }
+  toggle(name, force) {
+    if (force === undefined ? !this.values.has(name) : force) this.values.add(name);
+    else this.values.delete(name);
+    return this.values.has(name);
+  }
+  contains(name) { return this.values.has(name); }
+}
+
+function fakeNode() {
+  return {
+    classList: new FakeClassList(),
+    attributes: new Map([["hidden", ""]]),
+    setAttribute(name, value) { this.attributes.set(name, String(value)); },
+    removeAttribute(name) { this.attributes.delete(name); }
+  };
+}
+
+const tooltip = fakeNode();
+const context = vm.createContext({ el: { tooltip }, console });
+vm.runInContext(interaction, context, { filename: "app-interaction.js" });
+
+const svg = fakeNode();
+context.setSvgVisible(svg, false);
+assert.equal(svg.classList.contains("is-hidden"), true);
+assert.equal(svg.attributes.get("aria-hidden"), "true");
+context.setSvgVisible(svg, true);
+assert.equal(svg.classList.contains("is-hidden"), false);
+assert.equal(svg.attributes.get("aria-hidden"), "false");
+
+context.setTooltipVisible(true);
+assert.equal(tooltip.attributes.has("hidden"), false);
+assert.equal(tooltip.classList.contains("is-visible"), true);
+assert.equal(tooltip.attributes.get("aria-hidden"), "false");
+context.setTooltipVisible(false);
+assert.equal(tooltip.classList.contains("is-visible"), false);
+assert.equal(tooltip.attributes.get("aria-hidden"), "true");
+
+const laidOut = context.layoutHoverLabels([
+  { key: "buy", cy: 100 },
+  { key: "sell", cy: 105 },
+  { key: "market", cy: 108 }
+], 60, 180, 28);
+const positions = [...laidOut].sort((a, b) => a.labelY - b.labelY).map((entry) => entry.labelY);
+assert.ok(positions[1] - positions[0] >= 28);
+assert.ok(positions[2] - positions[1] >= 28);
+assert.ok(positions[0] >= 60 && positions[2] <= 180);
+
+assert.doesNotMatch(chart, /id="hover"\s+hidden/);
+assert.match(chart, /pointer-events="all"/);
+assert.match(interaction, /pointerenter/);
+assert.match(css, /\.tooltip\.is-visible/);
+assert.match(css, /\.capture\s*\{[^}]*pointer-events:\s*all/s);
+
+console.log("Chart interaction self-test passed");


### PR DESCRIPTION
## Что исправлено

Главная проблема была в механике hover-слоя SVG: элементы создавались с HTML-атрибутом `hidden`, а затем переключались через свойство `.hidden`. Для SVG это ненадёжно, поэтому маркеры могли так и оставаться невидимыми. Дополнительно прозрачная область захвата не задавала `pointer-events: all` явно.

Теперь видимость SVG управляется CSS-классом, а tooltip — отдельным классом `is-visible` с явным снятием старого атрибута `hidden`.

## Удобство графика

- наведение работает по всей области построения, а не только по маленькому кружку;
- появляется вертикальная линия выбранного времени;
- рядом с каждой выбранной кривой показывается цветная плашка с точным значением;
- снизу у курсора показывается точная дата и время;
- появляется подробная всплывающая карточка с покупкой, продажей, USDRUBF, спредом банка и двумя разрывами с рынком;
- точку можно закрепить кликом или касанием;
- доступны стрелки `←`/`→`, `Home`, `End`, сброс закрепления через `Esc`;
- последние значения трёх линий постоянно подписаны справа, поэтому текущий уровень виден даже без наведения;
- подписи автоматически раздвигаются и не накладываются друг на друга;
- линии, сетка и точки сделаны контрастнее;
- добавлена короткая подсказка по управлению прямо над графиком;
- при выборе значения MOEX больше не берётся будущая свеча: используется только последняя свеча на момент выбранной точки.

## Проверки

- добавлен regression self-test переключения SVG/tooltip и раскладки плашек;
- `npm test` теперь запускает тесты сборщика и взаимодействия с графиком;
- добавлен workflow `Validate site`, который на каждом PR выполняет `npm run check` и `npm run build`;
- Vercel Preview должен собраться автоматически.
