### PR TITLE
Починить наведение на график и добавить браузерный тест

### DIFF
--- a/.github/workflows/validate-chart-browser.yml
+++ b/.github/workflows/validate-chart-browser.yml
@@ -1,0 +1,42 @@
+name: Validate chart hover in browser
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  browser-hover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install Playwright client
+        run: npm install --no-save --no-package-lock playwright@1.57.0
+      - name: Build site
+        run: npm run build
+      - name: Test hover in Chromium
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python3 -m http.server 4173 -d _site >/tmp/ffin-http.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          node scripts/chart-browser-test.mjs
+      - name: Upload browser screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chart-hover-browser
+          path: chart-hover-e2e*.png
+          if-no-files-found: ignore

--- a/.github/workflows/validate-chart-browser.yml
+++ b/.github/workflows/validate-chart-browser.yml
@@ -33,10 +33,12 @@ jobs:
           server_pid=$!
           trap 'kill "$server_pid" 2>/dev/null || true' EXIT
           node scripts/chart-browser-test.mjs
-      - name: Upload browser screenshot
+      - name: Upload browser diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: chart-hover-browser
-          path: chart-hover-e2e*.png
+          path: |
+            chart-hover-e2e*.png
+            chart-hover-result.json
           if-no-files-found: ignore

--- a/app-hover-runtime.js
+++ b/app-hover-runtime.js
@@ -1,0 +1,92 @@
+// Runtime hardening for chart interaction.
+// The visual SVG capture rectangle remains the keyboard-accessible slider, while
+// pointer movement is also handled at chart-wrapper level. This makes hover work
+// even when another positioned child is the immediate event target.
+
+const bindChartInteractionOnCapture = bindChartInteraction;
+
+bindChartInteraction = function bindChartInteractionOnWholeChart() {
+  installEmptyOverlayGuard();
+  bindChartInteractionOnCapture();
+
+  const context = state.chartContext;
+  const capture = el.chart.querySelector(".capture");
+  if (!context?.events?.length || !capture) return;
+
+  state.chartSurfaceAbortController?.abort();
+  const controller = new AbortController();
+  state.chartSurfaceAbortController = controller;
+  const listenerOptions = { signal: controller.signal, passive: true };
+
+  const selectAtPointer = (clientX, clientY) => {
+    if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return false;
+    const rect = el.chart.getBoundingClientRect();
+    if (!rect.width || !rect.height) return false;
+
+    const svgX = (clientX - rect.left) / rect.width * context.width;
+    const svgY = (clientY - rect.top) / rect.height * context.height;
+    const insidePlot = svgX >= context.margin.left
+      && svgX <= context.width - context.margin.right
+      && svgY >= context.margin.top
+      && svgY <= context.height - context.margin.bottom;
+    if (!insidePlot) return false;
+
+    const ratio = Math.max(0, Math.min(1, (svgX - context.margin.left) / context.plotW));
+    const target = context.view.start + ratio * (context.view.end - context.view.start);
+    const nearest = nearestValue(context.events, target);
+    if (!Number.isFinite(nearest)) return false;
+
+    showSnapshot(nearest, true, false);
+    markChartInteracted();
+    return true;
+  };
+
+  const move = (event) => {
+    selectAtPointer(event.clientX, event.clientY);
+  };
+
+  // Listen on the wrapper rather than only on the SVG rectangle. Events from any
+  // child (SVG paths, labels, or overlays) bubble here, so the hover cannot be
+  // blocked by a positioned element above the SVG.
+  if ("PointerEvent" in window) {
+    el.wrap.addEventListener("pointerenter", move, listenerOptions);
+    el.wrap.addEventListener("pointermove", move, listenerOptions);
+    el.wrap.addEventListener("pointerdown", (event) => {
+      if (!selectAtPointer(event.clientX, event.clientY)) return;
+      state.pinned = true;
+      capture.classList.add("pinned");
+    }, listenerOptions);
+    el.wrap.addEventListener("pointerleave", () => {
+      if (!state.pinned) setTooltipVisible(false);
+    }, listenerOptions);
+  } else {
+    el.wrap.addEventListener("mouseenter", move, listenerOptions);
+    el.wrap.addEventListener("mousemove", move, listenerOptions);
+    el.wrap.addEventListener("mousedown", (event) => {
+      if (!selectAtPointer(event.clientX, event.clientY)) return;
+      state.pinned = true;
+      capture.classList.add("pinned");
+    }, listenerOptions);
+    el.wrap.addEventListener("mouseleave", () => {
+      if (!state.pinned) setTooltipVisible(false);
+    }, listenerOptions);
+  }
+};
+
+function installEmptyOverlayGuard() {
+  const empty = el.empty;
+  if (!empty) return;
+
+  const sync = () => {
+    const visible = !empty.hidden;
+    empty.style.display = visible ? "grid" : "none";
+    empty.style.pointerEvents = "none";
+    empty.setAttribute("aria-hidden", String(!visible));
+  };
+
+  if (!state.emptyOverlayObserver) {
+    state.emptyOverlayObserver = new MutationObserver(sync);
+    state.emptyOverlayObserver.observe(empty, { attributes: true, attributeFilter: ["hidden"] });
+  }
+  sync();
+}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <script defer src="./app-chart.js"></script>
   <script defer src="./app-interaction.js"></script>
   <script defer src="./app-helpers.js"></script>
+  <script defer src="./app-hover-runtime.js"></script>
   <script defer src="./app.js"></script>
 </head>
 <body>

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -5,7 +5,7 @@ const output = new URL("../_site/", import.meta.url);
 
 await rm(output, { recursive: true, force: true });
 await mkdir(output, { recursive: true });
-for (const item of ["index.html", "styles.css", "chart.css", "app-base.js", "app-ui.js", "app-chart.js", "app-interaction.js", "app-helpers.js", "app.js", "data"]) {
+for (const item of ["index.html", "styles.css", "chart.css", "app-base.js", "app-ui.js", "app-chart.js", "app-interaction.js", "app-helpers.js", "app-hover-runtime.js", "app.js", "data"]) {
   await cp(new URL(item, root), new URL(item, output), { recursive: true });
 }
 await writeFile(new URL(".nojekyll", output), "", "utf8");

--- a/scripts/chart-browser-test.mjs
+++ b/scripts/chart-browser-test.mjs
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import { chromium } from "playwright";
 
 const baseUrl = process.env.TEST_URL || "http://127.0.0.1:4173";
@@ -5,6 +6,7 @@ const browser = await chromium.launch({ headless: true });
 const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
 const consoleMessages = [];
 const pageErrors = [];
+let diagnostic = {};
 
 page.on("console", (message) => consoleMessages.push(`${message.type()}: ${message.text()}`));
 page.on("pageerror", (error) => pageErrors.push(error.stack || error.message));
@@ -24,17 +26,28 @@ try {
   await page.waitForFunction(() => document.querySelectorAll("#chart .series-line").length > 0, null, { timeout: 15_000 });
 
   const capture = page.locator("#chart .capture");
+  await capture.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(250);
   const box = await capture.boundingBox();
   if (!box) throw new Error("Capture rectangle has no bounding box");
 
-  await page.mouse.move(box.x + box.width * 0.52, box.y + box.height * 0.48);
-  await page.waitForTimeout(400);
+  const targetX = box.x + box.width * 0.52;
+  const targetY = box.y + box.height * 0.48;
+  const hitBeforeMove = await page.evaluate(({ x, y }) => {
+    const node = document.elementFromPoint(x, y);
+    return node ? `${node.tagName.toLowerCase()}#${node.id}.${node.getAttribute("class") || ""}` : null;
+  }, { x: targetX, y: targetY });
 
-  const hoverState = await page.evaluate(() => {
+  await page.mouse.move(targetX, targetY, { steps: 6 });
+  await page.waitForTimeout(450);
+
+  const hoverState = await page.evaluate(({ x, y }) => {
     const layer = document.querySelector("#hover");
     const tooltip = document.querySelector("#tooltip");
     const inspector = document.querySelector("#selected-time");
     const captureElement = document.querySelector("#chart .capture");
+    const empty = document.querySelector("#empty");
+    const hit = document.elementFromPoint(x, y);
     return {
       layerClass: layer?.getAttribute("class"),
       layerAriaHidden: layer?.getAttribute("aria-hidden"),
@@ -43,11 +56,15 @@ try {
       tooltipText: tooltip?.textContent?.replace(/\s+/g, " ").trim(),
       inspectorText: inspector?.textContent?.trim(),
       capturePointerEvents: captureElement ? getComputedStyle(captureElement).pointerEvents : null,
-      selectedMs: globalThis.state?.selectedMs ?? null
+      emptyHidden: empty?.hidden,
+      emptyDisplay: empty ? getComputedStyle(empty).display : null,
+      emptyPointerEvents: empty ? getComputedStyle(empty).pointerEvents : null,
+      hitAfterMove: hit ? `${hit.tagName.toLowerCase()}#${hit.id}.${hit.getAttribute("class") || ""}` : null
     };
-  });
+  }, { x: targetX, y: targetY });
 
-  console.log("Hover state:", JSON.stringify(hoverState, null, 2));
+  diagnostic = { baseUrl, targetX, targetY, hitBeforeMove, hoverState, pageErrors, consoleMessages };
+  console.log("Browser diagnostic:", JSON.stringify(diagnostic, null, 2));
   if (pageErrors.length) throw new Error(`Browser page errors:\n${pageErrors.join("\n\n")}`);
   if (hoverState.layerAriaHidden !== "false" || hoverState.layerClass?.includes("is-hidden")) {
     throw new Error(`Hover SVG layer did not become visible: ${JSON.stringify(hoverState)}`);
@@ -61,14 +78,19 @@ try {
   if (!hoverState.inspectorText || /Выберите точку/.test(hoverState.inspectorText)) {
     throw new Error(`Inspector was not updated: ${JSON.stringify(hoverState)}`);
   }
+  if (hoverState.emptyHidden && hoverState.emptyDisplay !== "none") {
+    throw new Error(`Hidden empty-state overlay is still displayed: ${JSON.stringify(hoverState)}`);
+  }
 
   await page.screenshot({ path: "chart-hover-e2e.png", fullPage: true });
   console.log("Real browser hover test passed");
 } catch (error) {
+  diagnostic.error = error.stack || String(error);
   console.error(error.stack || error);
   console.error("Console messages:\n" + consoleMessages.join("\n"));
   await page.screenshot({ path: "chart-hover-e2e-failure.png", fullPage: true }).catch(() => {});
   process.exitCode = 1;
 } finally {
+  await writeFile("chart-hover-result.json", `${JSON.stringify(diagnostic, null, 2)}\n`, "utf8").catch(() => {});
   await browser.close();
 }

--- a/scripts/chart-browser-test.mjs
+++ b/scripts/chart-browser-test.mjs
@@ -1,0 +1,74 @@
+import { chromium } from "playwright";
+
+const baseUrl = process.env.TEST_URL || "http://127.0.0.1:4173";
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 1 });
+const consoleMessages = [];
+const pageErrors = [];
+
+page.on("console", (message) => consoleMessages.push(`${message.type()}: ${message.text()}`));
+page.on("pageerror", (error) => pageErrors.push(error.stack || error.message));
+
+try {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const response = await page.goto(baseUrl, { waitUntil: "networkidle", timeout: 10_000 });
+      if (response?.ok()) break;
+    } catch (error) {
+      if (attempt === 29) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  await page.waitForSelector("#chart .capture", { state: "visible", timeout: 15_000 });
+  await page.waitForFunction(() => document.querySelectorAll("#chart .series-line").length > 0, null, { timeout: 15_000 });
+
+  const capture = page.locator("#chart .capture");
+  const box = await capture.boundingBox();
+  if (!box) throw new Error("Capture rectangle has no bounding box");
+
+  await page.mouse.move(box.x + box.width * 0.52, box.y + box.height * 0.48);
+  await page.waitForTimeout(400);
+
+  const hoverState = await page.evaluate(() => {
+    const layer = document.querySelector("#hover");
+    const tooltip = document.querySelector("#tooltip");
+    const inspector = document.querySelector("#selected-time");
+    const captureElement = document.querySelector("#chart .capture");
+    return {
+      layerClass: layer?.getAttribute("class"),
+      layerAriaHidden: layer?.getAttribute("aria-hidden"),
+      tooltipClass: tooltip?.getAttribute("class"),
+      tooltipAriaHidden: tooltip?.getAttribute("aria-hidden"),
+      tooltipText: tooltip?.textContent?.replace(/\s+/g, " ").trim(),
+      inspectorText: inspector?.textContent?.trim(),
+      capturePointerEvents: captureElement ? getComputedStyle(captureElement).pointerEvents : null,
+      selectedMs: globalThis.state?.selectedMs ?? null
+    };
+  });
+
+  console.log("Hover state:", JSON.stringify(hoverState, null, 2));
+  if (pageErrors.length) throw new Error(`Browser page errors:\n${pageErrors.join("\n\n")}`);
+  if (hoverState.layerAriaHidden !== "false" || hoverState.layerClass?.includes("is-hidden")) {
+    throw new Error(`Hover SVG layer did not become visible: ${JSON.stringify(hoverState)}`);
+  }
+  if (hoverState.tooltipAriaHidden !== "false" || !hoverState.tooltipClass?.includes("is-visible")) {
+    throw new Error(`Tooltip did not become visible: ${JSON.stringify(hoverState)}`);
+  }
+  if (!/Freedom|USDRUBF/.test(hoverState.tooltipText || "")) {
+    throw new Error(`Tooltip has no rate values: ${JSON.stringify(hoverState)}`);
+  }
+  if (!hoverState.inspectorText || /Выберите точку/.test(hoverState.inspectorText)) {
+    throw new Error(`Inspector was not updated: ${JSON.stringify(hoverState)}`);
+  }
+
+  await page.screenshot({ path: "chart-hover-e2e.png", fullPage: true });
+  console.log("Real browser hover test passed");
+} catch (error) {
+  console.error(error.stack || error);
+  console.error("Console messages:\n" + consoleMessages.join("\n"));
+  await page.screenshot({ path: "chart-hover-e2e-failure.png", fullPage: true }).catch(() => {});
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Причина

Предыдущее исправление меняло видимость SVG-маркеров, но не устраняло фактическую блокировку событий мыши. Абсолютный блок `#empty` имел собственное `display: grid`; несмотря на атрибут `hidden`, он оставался поверх SVG, показывал текст «За выбранный период данных пока нет» и перехватывал указатель. Кроме того, обработчики были привязаны только к внутреннему SVG-прямоугольнику `.capture`, что делало взаимодействие зависимым от конкретного hit target.

## Исправление

- состояние `#empty` теперь принудительно синхронизируется с атрибутом `hidden`;
- скрытый блок получает `display: none`, а в любом состоянии не перехватывает указатель (`pointer-events: none`);
- наведение дополнительно обрабатывается на всём `#chart-wrap`, поэтому событие работает независимо от того, какой SVG-элемент или дочерний слой оказался под курсором;
- исходный `.capture` сохранён для клавиатурной навигации и доступности;
- обработчики предыдущего рендера отменяются через `AbortController`, поэтому при смене периода они не накапливаются.

## Проверка в настоящем браузере

Добавлен Playwright-тест в Chromium. Он:

1. собирает опубликованную версию сайта;
2. прокручивает график в видимую область;
3. перемещает настоящий указатель мыши внутрь области построения;
4. проверяет вертикальную линию, цветные метки, всплывающую карточку и нижний инспектор;
5. проверяет, что скрытый `#empty` действительно имеет `display: none` и не перехватывает события.

Фактический результат теста:

```text
hit target: rect.capture
tooltip: tooltip is-visible
empty: hidden=true, display=none, pointer-events=none
selected point: 20 июл. 2026, 08:00
```

`Validate site`, браузерный Playwright-тест и Vercel Preview завершились успешно.